### PR TITLE
Fix: byte text, cursormoved error

### DIFF
--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -28,8 +28,15 @@ local function exceed(buf, win, min_colorcolumn)
    end
 
    local max_column = 0
+
    for _, line in pairs(lines) do
-      max_column = math.max(max_column, vim.fn.strdisplaywidth(line))
+      local err, column_number = pcall(vim.fn.strdisplaywidth, line)
+
+      if err == false then
+         return false
+      end
+
+      max_column = math.max(max_column, column_number)
    end
 
    return not is_disabled() and max_column > min_colorcolumn


### PR DESCRIPTION
- If it is a byte file, the string cannot be parsed.


<img width="664" alt="image" src="https://github.com/m4xshen/smartcolumn.nvim/assets/12395688/9524a234-851f-4b87-85f4-d3c1bbc8b826">


<img width="1277" alt="image" src="https://github.com/m4xshen/smartcolumn.nvim/assets/12395688/dc867322-1809-4eeb-9b0b-86fad578f907">
